### PR TITLE
Fix inhomogeneous shape array error in Gaussian_Gibbs.py

### DIFF
--- a/Gaussian_Gibbs.py
+++ b/Gaussian_Gibbs.py
@@ -4,7 +4,7 @@ from matplotlib import pyplot as plt
 # Numpy has Gaussian random number generator, so we don't use Box-Muller
 
 NITER = 10000
-A = [[1,0,1.0,1.0],
+A = [[1.0,1.0,1.0],
      [1.0,2.0,1.0],
      [1.0,1.0,2.0]]
 A = np.array(A)


### PR DESCRIPTION
This MR resolves an error encountered when running Gaussian_Gibbs.py:

```
$ python3 Gaussian_Gibbs.py 
Traceback (most recent call last):
  File "/home/user/MCMC-Sample-Codes/Gaussian_Gibbs.py", line 10, in <module>
    A = np.array(A)
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (3,) + inhomogeneous part.
```

By correcting "1,0" to "1.0" at A array, it is confirmed that the problem is solved.